### PR TITLE
Fix several problems with the score, pellets, display and next level

### DIFF
--- a/src/constants.asm
+++ b/src/constants.asm
@@ -21,7 +21,7 @@ endstruc
 
 %define SPRITE_SPEED_PIXELS 2
 
-%define NUMBER_OF_PELLETS 3
+%define NUMBER_OF_PELLETS 260
 
 ; speeds are in percentage just to be precise, so,  1% = 0.1 pixel (or 1 pixel for 10 frames) and 100%  = 10 pixels per frame ( can be set below)
 %define MAXIMUM_SPEED_PIXELS 10

--- a/src/constants.asm
+++ b/src/constants.asm
@@ -21,7 +21,7 @@ endstruc
 
 %define SPRITE_SPEED_PIXELS 2
 
-%define NUMBER_OF_PELLETS 260
+%define NUMBER_OF_PELLETS 3
 
 ; speeds are in percentage just to be precise, so,  1% = 0.1 pixel (or 1 pixel for 10 frames) and 100%  = 10 pixels per frame ( can be set below)
 %define MAXIMUM_SPEED_PIXELS 10

--- a/src/interraction.asm
+++ b/src/interraction.asm
@@ -143,7 +143,9 @@ section .text
             mov byte [strcBlinky + isChased], 0
             mov byte [strcClyde + isChased], 0
             mov byte [strcInky + isChased], 0
-            call BuildMazeModelBuffer
+            call resetPelletEaten
+            mov dh, FIRST_LINE_OF_MAZE
+            call MazeToBGbuffer.chooseFirstLine
             jmp start.resetPoint
         .endFunc:
         ret

--- a/src/interraction.asm
+++ b/src/interraction.asm
@@ -144,6 +144,7 @@ section .text
             mov byte [strcClyde + isChased], 0
             mov byte [strcInky + isChased], 0
             call resetPelletEaten
+            call BuildMazeModelBuffer
             mov dh, FIRST_LINE_OF_MAZE
             call MazeToBGbuffer.chooseFirstLine
             jmp start.resetPoint

--- a/src/main.asm
+++ b/src/main.asm
@@ -36,10 +36,9 @@ section .text
         call MazeToBGbuffer
         call BuildMazeModelBuffer
         call resetPelletEaten
-
+        
         .resetPoint:
-        mov dh, FIRST_LINE_OF_MAZE
-        call MazeToBGbuffer.chooseFirstLine
+        
         
         call DisplayMaze
         call displayScore


### PR DESCRIPTION
All the problems are descibed in the commits, but it were matter of score not increasing after next level, the unability to access to the third level, and some resets of the maze after esch pacman's death. The system of lives, score, pellet and levels suits now the functionnal.